### PR TITLE
New script to remove files on cmslpc EOS

### DIFF
--- a/python/removeFiles.py
+++ b/python/removeFiles.py
@@ -1,0 +1,142 @@
+# removeFiles.py
+
+import os
+import time
+import tools
+import argparse
+
+# TODO
+
+# DONE
+# - List all files in a directory.
+# - Extract number from file name.
+# - Add min/max number range as arguments for files to delete.
+# - Print files in min/max range and count files.
+# - Add flag to remove files (run deletion).
+# - Write eosrm command.
+# - Use eosrm command.
+
+# Get file number from the file name.
+def getFileNumber(file_name):
+    # Remove file extension from the file name.
+    file_name_no_ext = os.path.splitext(file_name)[0]
+    
+    # Get numbers from file name without the file extension.
+    delimiter = '_'
+    numbers = tools.getNumbers(file_name_no_ext, delimiter)
+    n_numbers = len(numbers)
+    
+    # Check for exactly one number.
+    if n_numbers == 0:
+        print("ERROR: No numbers found in the file name '{0}' using the delimiter '{1}'.".format(file_name, delimiter))
+        return -999
+    elif n_numbers > 1:
+        print("ERROR: Multiple numbers ({0} numbers) found in the file name '{1}' using the delimiter '{2}'.".format(n_numbers, file_name, delimiter))
+        return -999
+    else:
+        return numbers[0]
+
+def removeEOSFiles():
+    # options
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--min_number", "-a", default=-1,   help="minimum file number to delete (inclusive)")
+    parser.add_argument("--max_number", "-b", default=-1,   help="maximum file number to delete (inclusive)")
+    parser.add_argument("--directory",  "-d", default="",   help="directory containing root files")
+    parser.add_argument("--pattern",    "-p", default="",   help="pattern for root file names")
+    parser.add_argument("--remove",     "-r", default=False, action="store_true", help="remove files; flag to run file deletion")
+
+    options     = parser.parse_args()
+    min_number  = int(options.min_number)
+    max_number  = int(options.max_number)
+    directory   = options.directory
+    pattern     = options.pattern
+    remove      = options.remove
+
+    # EOS URL
+    eos_url = "root://cmseos.fnal.gov"
+    
+    # EOS URL tag: include backslash at the end!
+    eos_url_tag = eos_url
+    if eos_url_tag[-1] != "/":
+        eos_url_tag += "/"
+
+    if not directory:
+        print("ERROR: 'directory' is not set. Please provide a directory using the -d option.")
+        return
+    
+    if not pattern:
+        print("ERROR: 'pattern' is not set. Please provide a pattern using the -p option.")
+        return
+
+    # require min_number >= 0 and max_number >= 0
+    if min_number < 0 or max_number < 0:
+        print("ERROR: Please provide min/max file numbers >= 0 to delete (inclusive) using the -a (min) and -b (max) options.")
+        return
+
+    # require min_number <= max_number
+    if min_number > max_number:
+        print("ERROR: min_number ({0}) is greater than max_number ({1}); please change so that min_number is less than or equal to max_number.".format(min_number, max_number))
+        return
+    
+    # match pattern to base file name, but save full path to file
+    files = tools.get_eos_file_list(directory)
+    files_matching = [f for f in files if pattern in os.path.basename(f)]
+    files_matching_in_range = []
+    
+    print("----------------------------")
+    print("remove: {0}".format(remove))
+    print("directory: {0}".format(directory))
+    print("pattern: {0}".format(pattern))
+    print("min_number: {0}".format(min_number))
+    print("max_number: {0}".format(max_number))
+    print("----------------------------")
+    
+    # get matching files in range
+    print("matching files in range:")
+    for f in files_matching:
+        file_name = os.path.basename(f)
+        file_number = getFileNumber(file_name)
+        #print("Checking file '{0}': file_number = {1}, min_number = {2}, max_number = {3}".format(file_name, file_number, min_number, max_number))
+        if tools.numberInRange(file_number, min_number, max_number):
+            files_matching_in_range.append(f)
+            print(" - {0}; file number: {1}".format(file_name, file_number))
+    
+    n_files_total               = len(files)
+    n_files_matching            = len(files_matching)
+    n_files_matching_in_range   = len(files_matching_in_range)
+    
+    print("----------------------------")
+    print("Number of files (total): {0}".format(n_files_total))
+    print("Number of files containing the pattern '{0}': {1}".format(pattern, n_files_matching))
+    print("Number of files containing the pattern '{0}' and in the number range [{1}, {2}]: {3}".format(pattern, min_number, max_number, n_files_matching_in_range))
+    print("----------------------------")
+
+    # remove files
+    if remove:
+        for f in files_matching_in_range:
+            # remove EOS URL tag
+            f_to_rm = f.replace(eos_url_tag, "")
+            
+            #print("f: {0}".format(f))
+            #print("f_to_rm: {0}".format(f_to_rm))
+            
+            tools.eosrm(f_to_rm)
+        
+        print("These files were removed!")
+        print("Have a great day!")
+    else:
+        print("These files were not removed.")
+        print("Use the -r flag to remove the files matching the pattern in the specified number range.")
+    
+    print("----------------------------")
+
+def main():
+    t_start = time.time()
+    removeEOSFiles()
+    t_stop  = time.time()
+    t_run   = t_stop - t_start
+    print("run time (sec): {0:.3f}".format(t_run))
+
+if __name__ == "__main__":
+    main()
+

--- a/python/tools.py
+++ b/python/tools.py
@@ -1,0 +1,88 @@
+# tools.py
+
+import os
+import csv
+import glob
+import ROOT
+
+# creates directory if it does not exist
+def makeDir(dir_name):
+    if not os.path.exists(dir_name):
+        os.makedirs(dir_name)
+
+# get numbers from a string using a delimiter separation
+def getNumbers(string, delimiter):
+    numbers = [int(s) for s in string.split(delimiter) if s.isdigit()]
+    return numbers
+
+# determine if number is in range
+def numberInRange(number, range_min, range_max):
+    if number >= range_min and number <= range_max:
+        return True
+    else:
+        return False
+
+# takes a csv file as input and outputs data in a matrix
+def getData(input_file):
+    data = []
+    with open(input_file, "r") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            data.append(row)
+    return data
+
+# get chain from list of ROOT files
+def getChain(input_files, num_files):
+    verbose = True
+    
+    # use num_files as max if it is not negative
+    if num_files >= 0:
+        input_files = input_files[0:num_files]
+    n_input_files = len(input_files)
+    
+    # Create TChain
+    chain = ROOT.TChain('pixelTree')
+    
+    # Add files to chain
+    if verbose:
+        print("Adding {0} file(s) to chain:".format(n_input_files))
+    for f in input_files:
+        if verbose:
+            print(" - {0}".format(f))
+        chain.Add(f)
+    
+    return chain
+
+# get list of local files
+def get_file_list(dir_):
+    file_list_tmp = [os.path.join(dir_, f) for f in os.listdir(dir_) if (os.path.isfile(os.path.join(dir_, f)) and ('.root' in f))]
+    return file_list_tmp
+
+# get list of local files using glob
+def get_file_list_glob(directory, pattern="*.root"):
+    d = directory
+    if d[-1] != "/":
+        d += "/"
+    return glob.glob(d + pattern)
+
+# get list of EOS files
+def get_eos_file_list(path, eosurl="root://cmseos.fnal.gov"):
+    output = [] 
+    with eosls(path, "", eosurl) as files:
+        for f in files:
+            name = f.strip()
+            # add ROOT files to list
+            if name.endswith(".root"):
+                full_name = "{0}/{1}".format(eosurl, name)
+                output.append(full_name)
+    return output
+
+# eosls command using xrdfs
+def eosls(path, option="", eosurl="root://cmseos.fnal.gov"):
+    return os.popen("xrdfs %s ls %s %s" % (eosurl, option, path))
+
+# eosrm command using xrdfs
+def eosrm(path, option="", eosurl="root://cmseos.fnal.gov"):
+    return os.popen("xrdfs %s rm %s %s" % (eosurl, option, path))
+
+


### PR DESCRIPTION
New python script to automatically and systematically remove ROOT files stored on EOS at cmslpc.
- Provide EOS directory, file name pattern, and a file number range (min and max values) for files to remove (based on file names and numbers).
- By default, prints files that match pattern and are within the number range.
- Add the -r flat to remove files (run file deletion).
- Tested on files in test directory `/store/user/caleb/TestDir`.
- Used to remove a specified range of PixelTree ROOT files in `/store/user/lpcsusylep/PixelTrees` reduce space.

The same scripts are available here:
- https://github.com/ku-cms/trackIndepBeamSpot/blob/master/python/removeFiles.py
- https://github.com/ku-cms/trackIndepBeamSpot/blob/master/python/tools.py

Now tested and working in KU SUSY framework:
```
cd /uscms/home/caleb/nobackup/KU_SUSY_2022/CMSSW_10_6_5/src/KUEWKinoAnalysis
cmsenv
restenv
python python/removeFiles.py -d /store/user/caleb/TestDir -p PixelTree -a 21 -b 21
```
I am using this restenv alias:
```
alias restenv='source ~/lib/RestFrames/setup_RestFrames.sh'
```
Note:
For CMSSW_10_6_5, when using ROOT in python (PyROOT), you need to use python 2;
ROOT will not work in python 3!